### PR TITLE
Fix context management in crypto

### DIFF
--- a/lmc/src/crypto.h
+++ b/lmc/src/crypto.h
@@ -81,8 +81,8 @@ public:
 
 private:
 	RSA* pRsa;
-	QMap<QString, EVP_CIPHER_CTX> encryptMap;
-	QMap<QString, EVP_CIPHER_CTX> decryptMap;
+       QMap<QString, EVP_CIPHER_CTX*> encryptMap;
+       QMap<QString, EVP_CIPHER_CTX*> decryptMap;
 	int bits;
 	long exponent;
 };


### PR DESCRIPTION
## Summary
- keep AES context pointers in the maps
- clean up cipher contexts in destructor

## Testing
- `cppcheck --version`
- `cppcheck --enable=all -I lmc/src -I lmcapp/src lmc/src`

------
https://chatgpt.com/codex/tasks/task_b_685bc25e4f20832a8eaa4e865a2f5469