### PR TITLE
Add QMessageBrowser scroll test

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,12 @@ System tray support
 ===================
 On desktops that do not have a system tray, the system tray options will
 be grayed out in the Preferences dialog.
+
+Unit tests
+==========
+A basic regression test for `QMessageBrowser` is available under `tests/qmessagebrowser`.
+Build and run it using qmake:
+
+    qmake tests/qmessagebrowser/qmessagebrowser.pro
+    make
+    ./tst_qmessagebrowser

--- a/tests/qmessagebrowser/qmessagebrowser.pro
+++ b/tests/qmessagebrowser/qmessagebrowser.pro
@@ -1,0 +1,8 @@
+QT += widgets testlib
+CONFIG += testcase
+TEMPLATE = app
+TARGET = tst_qmessagebrowser
+SOURCES += ../../lmc/src/qmessagebrowser.cpp \
+           tst_qmessagebrowser.cpp
+HEADERS += ../../lmc/src/qmessagebrowser.h
+

--- a/tests/qmessagebrowser/tst_qmessagebrowser.cpp
+++ b/tests/qmessagebrowser/tst_qmessagebrowser.cpp
@@ -1,0 +1,38 @@
+#include <QtTest>
+#include "qmessagebrowser.h"
+
+class QMessageBrowserTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void insertWithoutScrolling();
+};
+
+void QMessageBrowserTest::insertWithoutScrolling()
+{
+    QMessageBrowser browser;
+    browser.resize(200, 100);
+
+    QString content;
+    for(int i = 0; i < 100; ++i)
+        content += QString("Line %1<br>").arg(i);
+    browser.setHtml(content);
+
+    browser.show();
+    QTest::qWaitForWindowExposed(&browser);
+
+    QScrollBar *sb = browser.verticalScrollBar();
+    sb->setValue(sb->maximum());
+    int before = sb->value();
+
+    auto data = browser.beginInsertWithoutScrolling();
+    browser.moveCursor(QTextCursor::Start);
+    browser.insertHtml("<p>prepended</p>");
+    browser.endInsertWithoutScrollig(data);
+
+    QCOMPARE(sb->value(), before);
+}
+
+QTEST_MAIN(QMessageBrowserTest)
+#include "tst_qmessagebrowser.moc"
+


### PR DESCRIPTION
## Summary
- add a QTest verifying `beginInsertWithoutScrolling` keeps the scrollbar
- set up a qmake project for the new test
- document how to build and run tests

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685bc0029228832aae9590a9a782076d